### PR TITLE
First stab at deploying executable built locally with docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.deploy
 *.stack-work/
 *.cabal
-stratosphere
+.cidfile

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "system-extra"]
+	path = system-extra
+	url = https://github.com/abailly/system-extra.git

--- a/examples/apigw-lambda-dynamodb/src/Main.hs
+++ b/examples/apigw-lambda-dynamodb/src/Main.hs
@@ -8,6 +8,7 @@ import           Control.Lens                    hiding (view, (.=))
 import           Control.Monad                   (forM, void, (<=<))
 import           Data.Aeson
 import qualified Data.HashMap.Strict             as SHM
+import           Data.Text                       (pack)
 import           Network.AWS.DynamoDB            (AttributeValue,
                                                   attributeValue, avS)
 import           Network.AWS.DynamoDB.DeleteItem
@@ -31,10 +32,10 @@ import           Qi.Program.Lambda.Interface     (LambdaProgram,
                                                   putDdbRecord, scanDdbRecords)
 import           Qi.Util.Api
 
+import           System.Environment
 import           Types
 
-
--- Use the curl commands below to test-drive the endpoints (substitute your unique api stage url first):
+-- Used the curl commands below to test-drive the endpoints (substitute your unique api stage url first):
 {-
 export API="https://gliqqtz1pi.execute-api.us-east-1.amazonaws.com/v1"
 curl -v -X POST -H "Content-Type: application/json" -d "{\"name\": \"cup\", \"shape\": \"round\", \"size\": 3}" "$API/things/cup"
@@ -47,8 +48,11 @@ curl -v -X GET "$API/things"
 
 
 main :: IO ()
-main =
-  "apigw-lambda-dynamodb" `withConfig` config
+main = do
+  args <- getArgs
+  case args of
+    (name:rest) -> withArgs rest (pack name `withConfig` config)
+    []          -> putStrLn "Please provide a unique application name to deploy your Lambda"
 
     where
       config :: ConfigProgram ()

--- a/examples/apigw-lambda-dynamodb/src/Main.hs
+++ b/examples/apigw-lambda-dynamodb/src/Main.hs
@@ -5,7 +5,7 @@
 module Main where
 
 import           Control.Lens                    hiding (view, (.=))
-import           Control.Monad                   (forM, void, (<=<))
+import           Control.Monad                   (forM, void)
 import           Data.Aeson
 import qualified Data.HashMap.Strict             as SHM
 import           Data.Text                       (pack)
@@ -52,7 +52,7 @@ main = do
   args <- getArgs
   case args of
     (target:name:rest) -> withArgs rest (withConfig (pack target) (pack name) config)
-    []                -> putStrLn "Please provide a build target name and a unique application name to deploy your Lambda"
+    _                  -> putStrLn "Please provide a build target name and a unique application name to deploy your Lambda"
 
     where
       config :: ConfigProgram ()

--- a/examples/apigw-lambda-dynamodb/src/Main.hs
+++ b/examples/apigw-lambda-dynamodb/src/Main.hs
@@ -51,8 +51,8 @@ main :: IO ()
 main = do
   args <- getArgs
   case args of
-    (name:rest) -> withArgs rest (pack name `withConfig` config)
-    []          -> putStrLn "Please provide a unique application name to deploy your Lambda"
+    (target:name:rest) -> withArgs rest (withConfig (pack target) (pack name) config)
+    []                -> putStrLn "Please provide a build target name and a unique application name to deploy your Lambda"
 
     where
       config :: ConfigProgram ()

--- a/examples/apigw-lambda-dynamodb/src/Main.hs
+++ b/examples/apigw-lambda-dynamodb/src/Main.hs
@@ -51,8 +51,8 @@ main :: IO ()
 main = do
   args <- getArgs
   case args of
-    (target:name:rest) -> withArgs rest (withConfig (pack target) (pack name) config)
-    _                  -> putStrLn "Please provide a build target name and a unique application name to deploy your Lambda"
+    (appName:rest) -> withArgs rest $ (pack appName) `withConfig` config
+    _              -> putStrLn "Please provide a unique application name for your qmulus"
 
     where
       config :: ConfigProgram ()

--- a/examples/apigw-lambda-s3/src/Main.hs
+++ b/examples/apigw-lambda-s3/src/Main.hs
@@ -3,11 +3,11 @@
 
 module Main where
 
-import           Control.Monad               (void)
 import           Data.Aeson
 import qualified Data.ByteString.Lazy        as LBS
+import           Data.Functor                (void)
+import           Data.Text                   (pack)
 import           Data.Text.Encoding          (decodeUtf8, encodeUtf8)
-
 import           Qi                          (withConfig)
 import           Qi.Config.AWS.Api           (ApiEvent (..),
                                               ApiVerb (Get, Post),
@@ -19,9 +19,9 @@ import           Qi.Program.Config.Interface (ConfigProgram, api,
                                               apiMethodLambda, apiResource,
                                               s3Bucket)
 import           Qi.Program.Lambda.Interface (LambdaProgram, getS3ObjectContent,
-                                              putS3ObjectContent, respond)
+                                              putS3ObjectContent)
 import           Qi.Util.Api
-
+import           System.Environment          (getArgs, withArgs)
 
 -- Use the two curl commands below to test-drive the two endpoints (substitute your unique api stage url first):
 --
@@ -30,18 +30,21 @@ import           Qi.Util.Api
 --
 
 main :: IO ()
-main =
-  "apigw-lambda-s3" `withConfig` config
+main = do
+  args <- getArgs
+  case args of
+    (target:name:rest) -> withArgs rest (withConfig (pack target) (pack name) config)
+    _                  -> putStrLn "Please provide a build target name and a unique application name to deploy your Lambda"
 
     where
       config :: ConfigProgram ()
       config = do
         bucketId  <- s3Bucket "things"
 
-        api "world" >>= \apiId ->
+        void $ api "world" >>= \apiId ->
           apiResource "things" apiId >>= \apiResourceId -> do
 
-            apiMethodLambda
+            void $ apiMethodLambda
               "createThing"
               Post
               apiResourceId
@@ -60,7 +63,7 @@ main =
         :: S3BucketId
         -> ApiEvent
         -> LambdaProgram ()
-      writeContentsLambda bucketId event@ApiEvent{_aeBody} = do
+      writeContentsLambda bucketId ApiEvent{_aeBody} = do
         putS3ObjectContent (s3Object bucketId) content
         successString "successfully added content"
 
@@ -68,6 +71,7 @@ main =
           content = case _aeBody of
             PlainTextBody t -> LBS.fromStrict $ encodeUtf8 t
             JsonBody v      -> encode v
+            _               -> error "failed to encode request body"
 
 
       readContentsLambda

--- a/examples/apigw-lambda-s3/src/Main.hs
+++ b/examples/apigw-lambda-s3/src/Main.hs
@@ -33,8 +33,8 @@ main :: IO ()
 main = do
   args <- getArgs
   case args of
-    (target:name:rest) -> withArgs rest (withConfig (pack target) (pack name) config)
-    _                  -> putStrLn "Please provide a build target name and a unique application name to deploy your Lambda"
+    (appName:rest) -> withArgs rest $ (pack appName) `withConfig` config
+    _              -> putStrLn "Please provide a unique application name for your qmulus"
 
     where
       config :: ConfigProgram ()

--- a/examples/simple-s3-copy/src/Main.hs
+++ b/examples/simple-s3-copy/src/Main.hs
@@ -8,6 +8,7 @@ module Main where
 import           Control.Lens
 import           Control.Monad               (void)
 
+import           Data.Text                   (pack)
 import           Qi                          (withConfig)
 import           Qi.Config.AWS.S3            (S3Event, s3Object, s3eObject,
                                               s3oBucketId, s3oKey)
@@ -16,16 +17,14 @@ import           Qi.Program.Config.Interface (ConfigProgram, s3Bucket,
                                               s3BucketLambda)
 import           Qi.Program.Lambda.Interface (LambdaProgram, getS3ObjectContent,
                                               putS3ObjectContent)
-
+import           System.Environment          (getArgs, withArgs)
 
 main :: IO ()
-main = do
-  -- Qmulus name must be globaly unique as the main deployment S3 bucket uses this name and
-  -- all underlying resource names use it as a prefix. To avoid collisions, rename this demo:
-  --
-  --   "myfancyuniquelynamedproject" `withConfig` config
-  --
-  "my-unique7657657-simple-s3-copy" `withConfig` config
+main =  do
+  args <- getArgs
+  case args of
+    (target:name:rest) -> withArgs rest (withConfig (pack target) (pack name) config)
+    _                  -> putStrLn "Please provide a build target name and a unique application name to deploy your Lambda"
 
     where
       config :: ConfigProgram ()

--- a/examples/simple-s3-copy/src/Main.hs
+++ b/examples/simple-s3-copy/src/Main.hs
@@ -23,8 +23,8 @@ main :: IO ()
 main =  do
   args <- getArgs
   case args of
-    (target:name:rest) -> withArgs rest (withConfig (pack target) (pack name) config)
-    _                  -> putStrLn "Please provide a build target name and a unique application name to deploy your Lambda"
+    (appName:rest) -> withArgs rest $ (pack appName) `withConfig` config
+    _              -> putStrLn "Please provide a unique application name for your qmulus"
 
     where
       config :: ConfigProgram ()

--- a/ghc-centos/Dockerfile
+++ b/ghc-centos/Dockerfile
@@ -25,3 +25,6 @@ RUN mkdir -p /opt/stack/bin
 RUN curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C /opt/stack/bin '*/stack'
 ENV PATH /opt/stack/bin/:$PATH
 RUN stack setup $GHC_VERSION
+
+## Install git
+RUN yum install -y git

--- a/ghc-centos/Dockerfile
+++ b/ghc-centos/Dockerfile
@@ -1,0 +1,27 @@
+## Dockerfile for a haskell environment in CentOS 6
+## Inspired by https://github.com/dimchansky/docker-centos6-haskell/blob/master/7.8.4/Dockerfile
+FROM       centos:7
+MAINTAINER Arnaud Bailly <arnaud@igitur.io>
+
+## Install dependencies
+RUN yum install -y curl\
+    gcc \
+    gmp-devel \
+    pcre-devel \
+    perl \
+    tar \
+    which \
+    xz \
+    zlib-devel \
+    && yum clean all --releasever=6 \
+    && ln -s /lib64/libtinfo.so.5 /lib64/libtinfo.so
+
+ENV GHC_VERSION=8.0.1
+
+RUN yum install -y make
+
+## Install stack
+RUN mkdir -p /opt/stack/bin
+RUN curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C /opt/stack/bin '*/stack'
+ENV PATH /opt/stack/bin/:$PATH
+RUN stack setup $GHC_VERSION

--- a/js/index.js
+++ b/js/index.js
@@ -21,7 +21,7 @@ exports.handler = function(event, context, callback) {
 
   console.log('input: \"', input, '\"')
 
-  const command = './' + appName + ' lbd ' + lbdName + ' \"' + input + '\"';
+  const command = './' + appName + ' foo bar lbd ' + lbdName + ' \"' + input + '\"';
   exec(command, {maxBuffer: maxBuffer}, (error, stdout, stderr) => {
     console.log('stdout: \"' + stdout + '\"');
     console.log('stderr: \"' + stderr + '\"');

--- a/js/index.js
+++ b/js/index.js
@@ -11,6 +11,8 @@ let formatError = (statusCode, message) => {
 
 exports.handler = function(event, context, callback) {
   const prefixedLambdaName = context.functionName;
+  // we extract the qmuli application name and the actual qmuli lambda name
+  // from the composite AWS lambda name (separated by '_')
   const appName = prefixedLambdaName.split('_', 1);
   const lbdName = prefixedLambdaName.split('_').slice(1);
   const input = JSON.stringify(event)
@@ -21,7 +23,9 @@ exports.handler = function(event, context, callback) {
 
   console.log('input: \"', input, '\"')
 
-  const command = './' + appName + ' foo bar lbd ' + lbdName + ' \"' + input + '\"';
+  // the executable built in the AWS environment using Docker will always
+  // be named 'lambda'
+  const command = './lambda ' + appName + ' lbd ' + lbdName + ' \"' + input + '\"';
   exec(command, {maxBuffer: maxBuffer}, (error, stdout, stderr) => {
     console.log('stdout: \"' + stdout + '\"');
     console.log('stderr: \"' + stderr + '\"');

--- a/package.yaml
+++ b/package.yaml
@@ -39,6 +39,8 @@ dependencies:
   - turtle
   - executable-path
   - heredoc
+  - system-extra
+  - process
   # - groundhog
   # - groundhog-th
   # - groundhog-sqlite

--- a/package.yaml
+++ b/package.yaml
@@ -19,6 +19,8 @@ dependencies:
   - base >= 4.8 && < 5
   - aeson >= 0.11.2.1
   - data-default
+  - directory
+  - unix
   - text
   - transformers
   - mtl

--- a/src/Qi.hs
+++ b/src/Qi.hs
@@ -33,10 +33,9 @@ import qualified Qi.Program.Lambda.Interpreters.IO    as LIO
 
 withConfig
   :: Text
-  -> Text
   -> ConfigProgram ()
   -> IO ()
-withConfig buildName appName configProgram = do
+withConfig appName configProgram = do
 
   if invalid appName
     then
@@ -50,7 +49,7 @@ withConfig buildName appName configProgram = do
         "cf":"deploy":[] -> do -- deploy CF template and the lambda package
           S3.createBucket appName
           S3.upload appName "cf.json" $ CF.render config
-          Lambda.deploy buildName appName
+          Lambda.deploy appName
 
         "cf":"create":[] -> do -- create CF stack
           CF.create appName

--- a/src/Qi.hs
+++ b/src/Qi.hs
@@ -22,9 +22,9 @@ import           Qi.Config.AWS.Lambda.Accessors       (getAllLambdas)
 import           Qi.Config.AWS.S3
 import qualified Qi.Config.AWS.S3.Event               as S3Event (parse)
 import           Qi.Config.CF                         as CF
+import qualified Qi.Deploy.CF                         as CF
 import qualified Qi.Deploy.Lambda                     as Lambda
 import qualified Qi.Deploy.S3                         as S3
-import qualified Qi.Deploy.CF                         as CF
 import           Qi.Program.Config.Interface          (ConfigProgram)
 import qualified Qi.Program.Config.Interpreters.Build as CB
 import           Qi.Program.Lambda.Interface          (LambdaProgram)
@@ -33,9 +33,10 @@ import qualified Qi.Program.Lambda.Interpreters.IO    as LIO
 
 withConfig
   :: Text
+  -> Text
   -> ConfigProgram ()
   -> IO ()
-withConfig appName configProgram = do
+withConfig buildName appName configProgram = do
 
   if invalid appName
     then
@@ -49,7 +50,7 @@ withConfig appName configProgram = do
         "cf":"deploy":[] -> do -- deploy CF template and the lambda package
           S3.createBucket appName
           S3.upload appName "cf.json" $ CF.render config
-          Lambda.deploy appName
+          Lambda.deploy buildName appName
 
         "cf":"create":[] -> do -- create CF stack
           CF.create appName

--- a/src/Qi/Deploy/Build.hs
+++ b/src/Qi/Deploy/Build.hs
@@ -2,15 +2,19 @@
 module Qi.Deploy.Build(build, buildConfig, Build) where
 
 import           System.Build
+import           System.Directory
 import           System.Docker
+import           System.Posix.Files
+import           System.Posix.Types
 import           System.Process
 
 data Build = Build { lambdaSrcDirectory :: FilePath
                    , lambdaTarget       :: BuildTarget
+                   , finalProgName      :: FilePath
                    }
 
-buildConfig :: FilePath -> String -> Build
-buildConfig srcDir exeTarget = Build srcDir (FullTarget "qmuli" exeTarget)
+buildConfig :: FilePath -> String -> String -> Build
+buildConfig srcDir exeTarget finalName = Build srcDir (FullTarget "qmuli" exeTarget) finalName
 
 build :: Build -> IO FilePath
 build Build{..} = do
@@ -18,14 +22,22 @@ build Build{..} = do
   -- build executable with docker
   exe <- stackInDocker (ImageName "ghc-centos:qmuli") lambdaSrcDirectory lambdaTarget
   -- pack executable with js shim in .zip file
-  packLambda exe
+  packLambda exe finalProgName
   return "lambda.zip"
     where
       buildDocker :: IO ()
       buildDocker = callProcess "docker" ["build", "-t", "ghc-centos:qmuli","ghc-centos" ]
 
-      packLambda :: FilePath -> IO ()
-      packLambda source = do
+      executableByAll :: FileMode
+      executableByAll = foldl unionFileModes nullFileMode [ ownerModes
+                                                          , groupReadMode, groupExecuteMode
+                                                          , otherReadMode, otherExecuteMode
+                                                          ]
+
+      packLambda :: FilePath -> FilePath -> IO ()
+      packLambda source target = do
         runner <- readFile "js/index.js"
         writeFile "index.js" runner
-        callProcess "zip" $ [ "lambda.zip", "index.js" , source ]
+        copyFile source target
+        target `setFileMode` executableByAll
+        callProcess "zip" $ [ "lambda.zip", "index.js" , target ]

--- a/src/Qi/Deploy/Build.hs
+++ b/src/Qi/Deploy/Build.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE RecordWildCards #-}
+module Qi.Deploy.Build where
+
+import           System.Build
+import           System.Docker
+import           System.Process
+
+data Build = Build { lambdaSrcDirectory :: FilePath
+                   , lambdaTargetName   :: String
+                   }
+
+build :: Build -> IO FilePath
+build Build{..} = do
+  buildDocker
+  -- build executable with docker
+  exe <- stackInDocker (ImageName "ghc-centos:qmuli") lambdaSrcDirectory lambdaTargetName
+  -- pack executable with js shim in .zip file
+  packLambda exe
+  return "lambda.zip"
+    where
+      buildDocker :: IO ()
+      buildDocker = callProcess "docker" ["build", "-t", "ghc-centos:qmuli","ghc-centos" ]
+
+      packLambda :: FilePath -> IO ()
+      packLambda source = do
+        runner <- readFile "js/index.js"
+        writeFile "run.js" runner
+        callProcess "zip" $ [ "lambda.zip", "run.js" , source ]

--- a/src/Qi/Deploy/Lambda.hs
+++ b/src/Qi/Deploy/Lambda.hs
@@ -21,7 +21,7 @@ deploy
   :: T.Text
   -> T.Text
   -> IO ()
-deploy buildName appName = fromString <$> build (Build "." (T.unpack buildName)) >>=
+deploy buildName appName = fromString <$> build (buildConfig "." (T.unpack buildName)) >>=
   \ lambdaPackagePath -> sh $ liftIO . uploadToS3 . T.unpack $ toTextIgnore lambdaPackagePath
   where
       uploadToS3

--- a/src/Qi/Deploy/Lambda.hs
+++ b/src/Qi/Deploy/Lambda.hs
@@ -21,7 +21,7 @@ deploy
   :: T.Text
   -> T.Text
   -> IO ()
-deploy buildName appName = fromString <$> build (buildConfig "." (T.unpack buildName)) >>=
+deploy buildName appName = fromString <$> build (buildConfig "." (T.unpack buildName) (T.unpack appName)) >>=
   \ lambdaPackagePath -> sh $ liftIO . uploadToS3 . T.unpack $ toTextIgnore lambdaPackagePath
   where
       uploadToS3

--- a/src/Qi/Deploy/Lambda.hs
+++ b/src/Qi/Deploy/Lambda.hs
@@ -4,31 +4,24 @@
 
 module Qi.Deploy.Lambda (deploy) where
 
-import           Control.Lens                  hiding (view)
-import qualified Data.ByteString.Lazy          as LBS
-import qualified Data.Text                     as T
-import           Network.AWS                   hiding (send)
-import qualified Network.AWS.S3                as A
-import           Prelude                       hiding (log)
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Text            as T
+import           Prelude              hiding (FilePath, log)
 import           Qi.Deploy.Build
-import qualified Qi.Deploy.S3                  as S3
-import           System.Environment.Executable (getExecutablePath)
-import           System.IO                     (stdout)
-import           Text.Heredoc                  (there)
-import           Turtle                        hiding (stdout)
+import qualified Qi.Deploy.S3         as S3
+import           Turtle               (FilePath, fromString, liftIO, sh, toText)
 
 
-log :: (MonadIO m) => T.Text -> m ()
-log = liftIO . echo
-
+toTextIgnore :: FilePath -> T.Text
 toTextIgnore x = case toText x of
-  Right s  -> s
-  Left err -> ""
+  Right s -> s
+  Left _  -> ""
 
 deploy
-  :: Text
+  :: T.Text
+  -> T.Text
   -> IO ()
-deploy appName = fromString <$> build (Build "." (T.unpack appName)) >>=
+deploy buildName appName = fromString <$> build (Build "." (T.unpack buildName)) >>=
   \ lambdaPackagePath -> sh $ liftIO . uploadToS3 . T.unpack $ toTextIgnore lambdaPackagePath
   where
       uploadToS3

--- a/src/Qi/Deploy/Lambda.hs
+++ b/src/Qi/Deploy/Lambda.hs
@@ -19,10 +19,12 @@ toTextIgnore x = case toText x of
 
 deploy
   :: T.Text
-  -> T.Text
   -> IO ()
-deploy buildName appName = fromString <$> build (buildConfig "." (T.unpack buildName) (T.unpack appName)) >>=
-  \ lambdaPackagePath -> sh $ liftIO . uploadToS3 . T.unpack $ toTextIgnore lambdaPackagePath
+  -- Note: the executable built in the AWS environment using Docker will always be named 'lambda'
+deploy appName = do
+  lambdaPackagePath <- fromString <$> build (buildConfig "." "lambda" $ T.unpack appName)
+  sh . liftIO . uploadToS3 . T.unpack $ toTextIgnore lambdaPackagePath
+
   where
       uploadToS3
         :: String

--- a/src/Qi/Deploy/Lambda.hs
+++ b/src/Qi/Deploy/Lambda.hs
@@ -10,12 +10,12 @@ import qualified Data.Text                     as T
 import           Network.AWS                   hiding (send)
 import qualified Network.AWS.S3                as A
 import           Prelude                       hiding (log)
+import           Qi.Deploy.Build
+import qualified Qi.Deploy.S3                  as S3
 import           System.Environment.Executable (getExecutablePath)
 import           System.IO                     (stdout)
 import           Text.Heredoc                  (there)
 import           Turtle                        hiding (stdout)
-
-import qualified Qi.Deploy.S3                  as S3
 
 
 log = liftIO . echo
@@ -28,7 +28,7 @@ deploy
   :: Text
   -> IO ()
 deploy appName = sh $ do
-  lambdaPackagePath <- createLambdaPackage
+  lambdaPackagePath <- liftIO $ build (Build "." (T.unpack appName))
   liftIO . uploadToS3 . T.unpack $ toTextIgnore lambdaPackagePath
 
   where

--- a/src/Qi/Program/Lambda/Interface.hs
+++ b/src/Qi/Program/Lambda/Interface.hs
@@ -7,7 +7,6 @@ module Qi.Program.Lambda.Interface where
 
 import           Control.Monad.Operational       (Program, singleton)
 import           Data.Aeson                      (Value)
-import qualified Data.ByteString                 as BS
 import qualified Data.ByteString.Lazy            as LBS
 import           Network.AWS.DynamoDB.DeleteItem
 import           Network.AWS.DynamoDB.GetItem
@@ -65,21 +64,28 @@ data LambdaInstruction a where
 
 -- S3
 
+getS3ObjectContent :: S3Object -> LambdaProgram LBS.ByteString
 getS3ObjectContent = singleton . GetS3ObjectContent
 
+putS3ObjectContent :: S3Object -> LBS.ByteString -> LambdaProgram ()
 putS3ObjectContent s3Obj = singleton . PutS3ObjectContent s3Obj
 
 
 -- DDB
 
+scanDdbRecords :: DdbTableId -> LambdaProgram ScanResponse
 scanDdbRecords = singleton . ScanDdbRecords
 
+getDdbRecord :: DdbTableId -> DdbAttrs -> LambdaProgram GetItemResponse
 getDdbRecord ddbTableId = singleton . GetDdbRecord ddbTableId
 
+putDdbRecord :: DdbTableId -> DdbAttrs -> LambdaProgram PutItemResponse
 putDdbRecord ddbTableId = singleton . PutDdbRecord ddbTableId
 
+deleteDdbRecord :: DdbTableId -> DdbAttrs -> LambdaProgram DeleteItemResponse
 deleteDdbRecord ddbTableId = singleton . DeleteDdbRecord ddbTableId
 
 -- Util
 
+respond :: Int -> Value -> LambdaProgram ()
 respond status = singleton . Respond status

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,6 +10,7 @@ packages:
 - location:
     git: https://github.com/ababkin/stratosphere.git
     commit: 002208ba0a6e19174c6ae4bf581ade6701708e1a
+- 'system-extra'
 # - location:
     # git: https://github.com/lykahb/groundhog.git
     # commit: fa62710364d55fdbc6de5a4a33f3a8d0d9d125dd

--- a/stack.yaml
+++ b/stack.yaml
@@ -44,7 +44,7 @@ extra-package-dbs: []
   # enable: true
 
 # ghc-options:
-  # "*": -static -optc-static -optl-static -optl-pthread
+#  "*": -Wno-unused-do-bind
 
 # Control whether we use the GHC we find on the path
 # system-ghc: true


### PR DESCRIPTION
This is a first stab at using docker to build locally an executable to be run on AWS Lambda. 
Some notes:

* It uses my [system-extra](https://github.com/abailly/system-extra) package as a submodule to invoke docker
* The built package does not seem to work currently, here is the error I got when trying to invoke API:
```
$ curl -v -X POST -H "Content-Type: application/json" -d "{\"name\": \"cup\", \"shape\": \"round\", \"size\": 3}" "$API/things/cup"
*   Trying 54.192.185.94...
* Connected to lzrfju1akf.execute-api.us-east-1.amazonaws.com (54.192.185.94) port 443 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
* Server certificate: *.execute-api.us-east-1.amazonaws.com
* Server certificate: Symantec Class 3 Secure Server CA - G4
* Server certificate: VeriSign Class 3 Public Primary Certification Authority - G5
> POST /v1/things/cup HTTP/1.1
> Host: lzrfju1akf.execute-api.us-east-1.amazonaws.com
> User-Agent: curl/7.43.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 44
> 
* upload completely sent off: 44 out of 44 bytes
< HTTP/1.1 200 OK
< Content-Type: application/json
< Content-Length: 164
< Connection: keep-alive
< Date: Wed, 30 Nov 2016 09:54:03 GMT
< Access-Control-Allow-Headers: Content-Type,X-Amz-Date,Authorization,X-Api-Key
< Access-Control-Allow-Methods: DELETE,GET,HEAD,POST,PUT,OPTIONS,TRACE
< Access-Control-Allow-Origin: *
< x-amzn-RequestId: ed110adb-b6e2-11e6-8962-8bd0479d2e61
< X-Amzn-Trace-Id: Root=1-583ea1bb-d4590527a8a7716e6f2dc7fd
< X-Cache: Miss from cloudfront
< Via: 1.1 a98053a65d016ea1580cbb8422815b10.cloudfront.net (CloudFront)
< X-Amz-Cf-Id: f7J6Hun6w6CmMrF7tZgphjbLDtnDapNWFaXjPzOQ192Jmbw7ELcy4g==
< 
{"errorMessage":"Cannot find module '/var/task/index'","errorType":"Error","stackTrace":["Module.require (module.js:353:17)","require (internal/module.js:12:17)"]}
```

